### PR TITLE
chore(README): linting + formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-## Pathfinder2
+# Pathfinder2
 
 Pathfinder is a collection of tools related to
 computing transitive transfers in the
 [CirclesUBI](https://joincircles.net) trust graph.
 
-### Building
+## Building
 
-This is a rust project, so assuming `cargo` is installed, `cargo build`
-creates two binaries: The server (default) and the cli.
+This is a rust project, so assuming `cargo` is installed, `cargo build` creates three binaries:  
+The `server` (default), the `cli` and the `convert` tool.
 
-Both need a file that contains the trust graph edges to work.
+All need a file that contains the trust graph edges to work.  
 A reasonably up to date edge database file can be obtained from
-https://chriseth.github.io/pathfinder2/edges.dat
 
+- https://chriseth.github.io/pathfinder2/edges.dat
 
-#### Using the Server
+### Using the Server
 
 `cargo run --release <ip-address>:<port>` will start a JSON-RPC server listening on the given port.
 
@@ -29,18 +29,15 @@ Number of worker threads: 4
 
 Size of request queue: 10
 
-#### Using the CLI
+### Using the CLI
 
-The CLI will load an edge database file and compute the transitive transfers
-from one source to one destination. You can limit the number of hops to explore
-and the maximum amount of circles to transfer.
-
+The CLI will load an edge database file and compute the transitive transfers from one source to one destination. You can limit the number of hops to explore and the maximum amount of circles to transfer.
 
 The options are:
 
 `cargo run --release --bin cli <from> <to> <edges.dat> [<max_hops> [<max_amount>]] [--dot <dotfile>]`
 
-For example 
+For example:
 
 `cargo run --release --bin cli 0x9BA1Bcd88E99d6E1E03252A70A63FEa83Bf1208c 0x42cEDde51198D1773590311E2A340DC06B24cB37 edges.dat 3 1000000000000000000`
 
@@ -48,12 +45,12 @@ Computes a transfer of at most `1000000000000000000`, exploring 3 hops.
 
 If you specify `--dot <dotfile>`, a graphviz/dot representation of the transfer graph is written to the given file.
 
-#### Conversion Tool
+### Conversion Tool
 
-The conversion tool can convert between different ways of representing the edge and trust relations in the circles system.
+The conversion tool can convert between different ways of representing the edge and trust relations in the circles system.  
 All data formats are described in https://hackmd.io/Gg04t7gjQKeDW2Q6Jchp0Q
 
-It can read an edge database both in CSV and binary formatand a "safe database" in json and binary format.
+It can read an edge database both in CSV and binary formatand a "safe database" in json and binary format.  
 The output is always an edge database in either binary or CSV format.
 
 Example:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pathfinder2
 
-Pathfinder is a collection of tools related to
-computing transitive transfers in the
+Pathfinder is a collection of tools related to  
+computing transitive transfers in the  
 [CirclesUBI](https://joincircles.net) trust graph.
 
 ## Building


### PR DESCRIPTION
This follows some suggestions of a Markdown linter (Headlines one level up, no empty lines), and employs Markdown formatting rules, where they appear to be implied. This is the case with paragraphs that have multiple line beginnings without an empty line between them, where two spaces were added to line endings, where a line break appears to be implied.