### PR TITLE
Validate the U256 input string for 'compute_transfer'

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -21,6 +21,20 @@ struct JsonRpcRequest {
     params: JsonValue,
 }
 
+struct InputValidationError(String);
+impl Error for InputValidationError {}
+
+impl Debug for InputValidationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Error: {}", self.0)
+    }
+}
+impl Display for InputValidationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Error: {}", self.0)
+    }
+}
+
 pub fn start_server(listen_at: &str, queue_size: usize, threads: u64) {
     let edges: Arc<RwLock<Arc<EdgeDB>>> = Arc::new(RwLock::new(Arc::new(EdgeDB::default())));
 
@@ -133,21 +147,6 @@ fn load_safes_binary(edges: &RwLock<Arc<EdgeDB>>, file: &str) -> Result<usize, B
     *edges.write().unwrap() = Arc::new(updated_edges);
     Ok(len)
 }
-
-struct InputValidationError(String);
-
-impl Debug for InputValidationError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Error: {}", self.0)
-    }
-}
-impl Display for InputValidationError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Error: {}", self.0)
-    }
-}
-
-impl Error for InputValidationError {}
 
 fn compute_transfer(
     request: JsonRpcRequest,


### PR DESCRIPTION
The pathfinder didn't validate all it's inputs in the compute_transfers function which can cause crashes when presented with the wrong number format.

Each invalid request killed one thread:
```
Running `target/release/server '0.0.0.0:4444'`
Request: {"method":"compute_transfer","params":{"from":"0x20E024439fa1320C3E31a6e4677D503889867DDd","to":"0x9BA1Bcd88E99d6E1E03252A70A63FEa83Bf1208c","value":"200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","iterative":false,"prune":true}}
Computing flow
thread '<unnamed>' panicked at 'assertion failed: digits.len() <= 4', src/types/u256.rs:103:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Request: {"method":"compute_transfer","params":{"from":"0x20E024439fa1320C3E31a6e4677D503889867DDd","to":"0x9BA1Bcd88E99d6E1E03252A70A63FEa83Bf1208c","value":"200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","iterative":false,"prune":true}}
Computing flow
thread '<unnamed>' panicked at 'assertion failed: digits.len() <= 4', src/types/u256.rs:103:13
Request: {"method":"compute_transfer","params":{"from":"0x20E024439fa1320C3E31a6e4677D503889867DDd","to":"0x9BA1Bcd88E99d6E1E03252A70A63FEa83Bf1208c","value":"200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","iterative":false,"prune":true}}
Computing flow
thread '<unnamed>' panicked at 'assertion failed: digits.len() <= 4', src/types/u256.rs:103:13
Request: {"method":"compute_transfer","params":{"from":"0x20E024439fa1320C3E31a6e4677D503889867DDd","to":"0x9BA1Bcd88E99d6E1E03252A70A63FEa83Bf1208c","value":"200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","iterative":false,"prune":true}}
Computing flow
thread '<unnamed>' panicked at 'assertion failed: digits.len() <= 4', src/types/u256.rs:103:13
```
After that, the pathfinder's main thread kept running, but since there were no workers left, it didn't process any requests.