### PR TITLE
Add Clap to CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Cargo.lock
 
 # Capacity graph runtime state
 capacity_graph.db
+
+edges.dat

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ default-run = "server"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.2.4", features = ["derive", "cargo"] }
 eth_checksum = "0.1.2"
 json = "^0.12.4"
 num-bigint = "^0.4.3"


### PR DESCRIPTION
Hi everyone, I've made some changes that I hope will improve the CLI experience.
I'm open to feedback or suggestions.

- Add clap to parse the command line arguments
    - It adds clap to the root directory since the CLI is under the bin directory.
    - If this is an issue, then I could move the CLI into it's own workspace and consume the crate as a library.

I've tested the CLI and I haven't encountered any problems. However I'd like to hear your feedback on the argument descriptions.
If necessary I'd be happy to change it.